### PR TITLE
Updated button colours for locks

### DIFF
--- a/app.js
+++ b/app.js
@@ -2990,7 +2990,7 @@ exports.default = _modal2.default.extend({
 });
 
 },{"../modal":47,"./template.html":67}],67:[function(require,module,exports){
-module.exports = "<ui-modal-template><h2 class=\"title title--center\">Hurry up, time is ticking!</h2><ui-timer color=gray center></ui-timer><ui-button v-if=locked @click=unlock color=red center>Unlock</ui-button><ui-button v-else @click=lock color=green center>Lock</ui-button></ui-modal-template>";
+module.exports = "<ui-modal-template><h2 class=\"title title--center\">Hurry up, time is ticking!</h2><ui-timer color=gray center></ui-timer><ui-button v-if=locked @click=unlock color=green center>🔓Unlock</ui-button><ui-button v-else @click=lock color=red center>🔒Lock</ui-button></ui-modal-template>";
 
 },{}],68:[function(require,module,exports){
 'use strict';

--- a/game.html
+++ b/game.html
@@ -45,7 +45,7 @@
               <a class="button button--solid button--green" href="game.html">Yes</a>
             </div>
             <div class="align__cell">
-              <ui-button @click="toggleConfirmModal" color="green">Cancel</ui-button>
+              <ui-button @click="toggleConfirmModal" color="red">Cancel</ui-button>
             </div>
           </div>
         </ui-modal>


### PR DESCRIPTION
Updated a "cancel" button that I missed with the previous PR.

Updated on "lock"- and "unlock"-buttons by changing the following and adding flair:

1. Unlocked: Green + 🔒 
2. Locked: Red + 🔓 